### PR TITLE
Adds support for BearerToken for InternalRealm and skips credential matching for jwtToken

### DIFF
--- a/sandbox/libs/authn/src/main/java/org/opensearch/authn/AuthenticationTokenHandler.java
+++ b/sandbox/libs/authn/src/main/java/org/opensearch/authn/AuthenticationTokenHandler.java
@@ -12,8 +12,6 @@ import org.apache.shiro.authc.UsernamePasswordToken;
 import org.opensearch.authn.tokens.BasicAuthToken;
 import org.opensearch.authn.tokens.BearerAuthToken;
 import org.apache.shiro.authc.BearerToken;
-import org.apache.cxf.rs.security.jose.jwt.JwtToken;
-import org.opensearch.authn.jwt.JwtVerifier;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -85,13 +83,6 @@ public class AuthenticationTokenHandler {
     private static AuthenticationToken handleBearerAuth(final BearerAuthToken token) throws RuntimeException {
 
         String encodedJWT = token.getHeaderValue().substring("Bearer".length()).trim();
-
-        // This just verifies the token and returns a decoded one in the process--the decoded version is not used here though
-        try {
-            JwtToken jwtToken = JwtVerifier.getVerifiedJwtToken(encodedJWT);
-        } catch (RuntimeException e) {
-            throw (e); // Could not verify the JWT token--throw this error to prevent the return
-        }
         return new BearerToken(encodedJWT);
     }
 }

--- a/sandbox/libs/authn/src/main/java/org/opensearch/authn/realm/InternalRealm.java
+++ b/sandbox/libs/authn/src/main/java/org/opensearch/authn/realm/InternalRealm.java
@@ -8,9 +8,11 @@
 
 package org.opensearch.authn.realm;
 
+import org.apache.cxf.rs.security.jose.jwt.JwtToken;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.BearerToken;
 import org.apache.shiro.authc.CredentialsException;
 import org.apache.shiro.authc.IncorrectCredentialsException;
 import org.apache.shiro.authc.SimpleAuthenticationInfo;
@@ -20,6 +22,7 @@ import org.apache.shiro.realm.AuthenticatingRealm;
 
 import org.opensearch.authn.StringPrincipal;
 import org.opensearch.authn.User;
+import org.opensearch.authn.jwt.JwtVerifier;
 
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
@@ -89,11 +92,28 @@ public class InternalRealm extends AuthenticatingRealm {
         return userRecord;
     }
 
+    // TODO: Revisit this
+    // This was overridden to support all kinds of AuthTokens
+    @Override
+    public boolean supports(AuthenticationToken token) {
+        return true;
+    }
+
+    @Override
+    protected void assertCredentialsMatch(AuthenticationToken token, AuthenticationInfo info) throws AuthenticationException {
+        if (token instanceof BearerToken) {
+            // TODO: Check if this is correct
+            // Token has previously been verified at doGetAuthenticationInfo
+            // no auth required as bearer token is assumed to have correct credentials
+        } else if (token instanceof UsernamePasswordToken) {
+            super.assertCredentialsMatch(token, info); // continue as normal for basic-auth token
+        }
+    }
+
     @Override
     protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token) throws AuthenticationException {
         if (token instanceof UsernamePasswordToken) {
             String username = ((UsernamePasswordToken) token).getUsername();
-            final char[] password = ((UsernamePasswordToken) token).getPassword();
             // Look up the user by the provide username
             User userRecord = getInternalUser(username);
             // Check for other things, like a locked account, expired password, etc.
@@ -117,6 +137,20 @@ public class InternalRealm extends AuthenticatingRealm {
                 // Bad password
                 throw new IncorrectCredentialsException(INCORRECT_CREDENTIALS_MESSAGE);
             }
+        } else if (token instanceof BearerToken) {
+            JwtToken jwtToken;
+
+            // Verify the validity of JWT token
+            try {
+                jwtToken = JwtVerifier.getVerifiedJwtToken(((BearerToken) token).getToken());
+            } catch (RuntimeException e) {
+                throw new IncorrectCredentialsException(e.getMessage()); // Invalid Token
+            }
+
+            String subject = jwtToken.getClaims().getSubject();
+
+            // We need to extract the subject here to create an identity subject that can be utilized across the realm
+            return new SimpleAuthenticationInfo(subject, null, realmName);
         }
         // Don't know what to do with this token
         throw new CredentialsException();


### PR DESCRIPTION
Signed-off-by: Darshit Chanpura <dchanp@amazon.com>



### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
